### PR TITLE
Render Mermaid diagrams locally

### DIFF
--- a/com.oxygenxml.diagrams.svg/xsl/xhtmlSVG.xsl
+++ b/com.oxygenxml.diagrams.svg/xsl/xhtmlSVG.xsl
@@ -10,8 +10,7 @@ available in the base directory of this plugin.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   version="2.0"
   xmlns:saxon="http://saxon.sf.net/"
-  xmlns:converter="java:com.oxygenxml.plantuml.svg.PlantumlToSVG"
-  xmlns:base64Encoder="java:com.oxygenxml.mermaid.Base64Encoder" exclude-result-prefixes="saxon converter base64Encoder">
+	xmlns:converter="java:com.oxygenxml.plantuml.svg.PlantumlToSVG">
   <xsl:param name="plantuml.include.path"/>
   
   <!-- Plant UML -->
@@ -25,9 +24,14 @@ available in the base directory of this plugin.
   
   <!-- Mermaid -->
   <xsl:template match="*[contains(@class, ' topic/foreign ')][contains(@outputclass, 'embed-mermaid-diagram')] | *[contains(@class, ' topic/mermaid-diagram ')]" priority="10">
-    <span>
-      <xsl:call-template name="commonattributes"/>
-      <xsl:copy-of select="document(concat('https://mermaid.ink/svg/', base64Encoder:encode(string-join(text(), ''))))"/>
-    </span>
+    <div><script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@9/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+    <pre>
+	<xsl:call-template name="commonattributes"/>
+    <xsl:copy-of select="string-join(text(), '')"/>
+    </pre>
+	</div>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
author darrenn-jackson <darrenn.jackson@gmail.com> 1676392110 -0600 committer Darrenn Jackson <darrenn.jackson@hpe.com> 1676395010 -0600

Local browser rendering for Mermaid diagrams

While using this plugin for one of my docs, I frequently got HTTP 503 error codes during the build process from the Mermaid web service. This will likely happen to anyone else who uses this plugin. These changes cause the browser to download the Mermaid JS library and render the diagram during page load.

Signed-off-by: Darrenn Jackson <darrenn.jackson@hpe.com>